### PR TITLE
Compatibility with legacy versions of Pillow

### DIFF
--- a/gooey/gui/imageutil.py
+++ b/gooey/gui/imageutil.py
@@ -20,7 +20,12 @@ def resizeImage(im, targetHeight):
 
 
 def wrapBitmap(im, parent):
-    bitmapData = wx.Bitmap.FromBufferRGBA(im.size[0], im.size[1], im.convert('RGBA').tobytes())
+    try:
+        rgba = im.convert('RGBA').tobytes()
+    except AttributeError:
+        rgba = im.convert('RGBA').tostring()
+
+    bitmapData = wx.Bitmap.FromBufferRGBA(im.size[0], im.size[1], rgba)
     return wx.StaticBitmap(parent, bitmap=bitmapData)
 
 


### PR DESCRIPTION
Old versions of Pillow:Image don't support .tobytes(), so we use .tostring() instead.